### PR TITLE
Allow numpy and jinja versions more freedom

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "empiarreader"
-version = "0.0.16"
+version = "0.0.17"
 description = "EMPIARReader provides utilities to lazily load data from EMPIAR into a machine-learning-friendly dataset format or to locally download the files."
 readme = "README.md"
 requires-python = ">=3.8"
@@ -25,7 +25,7 @@ dependencies = [
     "aiohttp>=3.8.3",
     "setuptools>=67.7.2",
     "pre-commit>=3.3.3",
-    "numpy>=1.23.3",
+    "numpy>=1.23.3,<2",
     "jinja2>=3.1.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
     "aiohttp>=3.8.3",
     "setuptools>=67.7.2",
     "pre-commit>=3.3.3",
-    "numpy==1.23.3",
-    "jinja2==3.1.0"
+    "numpy>=1.23.3",
+    "jinja2>=3.1.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Allow numpy and jinja versions more freedom with a version bump